### PR TITLE
Read environment variable instead of argv for the port value

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To start the server and deploy from Node.js
 ```javascript
 const { startGanacheServerAndDeployEthrDidRegistry } = require('@rsksmart/ethr-did-utils')
 
-const port = process.argv[2] || 8545
+const port = process.env.PORT || 8545
 
 startGanacheServerAndDeployEthrDidRegistry(port).then(({ blockchain, server, rpcUrl, eth, registryAddress, registry }) => {
   console.log(`Ganache started on port ${port} - rpcUrl: ${rpcUrl}`)

--- a/demo.js
+++ b/demo.js
@@ -1,6 +1,6 @@
 const { startGanacheServerAndDeployEthrDidRegistry } = require('.')
 
-const port = process.argv[2] || 8545
+const port = process.env.PORT || 8545
 
 startGanacheServerAndDeployEthrDidRegistry(port).then(({ blockchain, server, rpcUrl, eth, registryAddress, registry }) => {
   console.log(`Ganache started on port ${port} - rpcUrl: ${rpcUrl}`)

--- a/scripts/startGanacheAndDeploy.js
+++ b/scripts/startGanacheAndDeploy.js
@@ -1,6 +1,6 @@
 const { startGanacheServerAndDeployEthrDidRegistry } = require('..')
 
-const port = process.argv[2] || 8545
+const port = process.env.PORT || 8545
 
 startGanacheServerAndDeployEthrDidRegistry(port).then(({ blockchain, server, rpcUrl, eth, registryAddress, registry }) => {
   console.log(`Ganache started on port ${port} - rpcUrl: ${rpcUrl}`)


### PR DESCRIPTION
# Description
Update startGanacheAndDeploy.js script to use the environment variable instead of argv.

- Replaced `argv` with env.PORT.
- Now we can provide `PORT` environment variable when executing the script like this:
```
$ PORT=7545 npm run start-ganache-and-deploy
```

# Output
![did_Screenshot_2020-10-14_19-56-37](https://user-images.githubusercontent.com/19724279/96001688-05abfb00-0e58-11eb-927a-b13fa4619cd1.png)

