### PR TITLE
Deploy ethr-did-registry to already initiated ganache instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   ],
   "scripts": {
     "test": "npx jest",
-    "start-ganache-and-deploy": "node scripts/startGanacheAndDeploy"
+    "start-ganache-and-deploy": "node scripts/startGanacheAndDeploy",
+    "deploy-registry": "node scripts/deployEthrDidRegistry.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/deployEthrDidRegistry.js
+++ b/scripts/deployEthrDidRegistry.js
@@ -1,0 +1,13 @@
+const Eth = require('ethjs')
+
+const { deployEthrDidRegistry } = require('..')
+
+const port = process.env.PORT || 8545;
+
+const rpcUrl = `http://localhost:${port}`;
+const eth = new Eth(new Eth.HttpProvider(rpcUrl))
+
+deployEthrDidRegistry(eth).then(({ registryAddress, registry }) => {
+  console.log(`Ethr DID Registry depoyed - registryAddress: ${registryAddress}`)
+  console.log(`netowrks: [ {rpcUrl: ${rpcUrl}, registryAddress: ${registryAddress} }]`)
+})


### PR DESCRIPTION
# Description
If we have ganache workspace already and would like to deploy the did-registry to the existing Ganache instance, this tool will enable the deployment of did registry directly.

## Usage
```
PORT={port} npm run deploy-registry
```
or
```
PORT={port} yarn deploy-registry
```
Note: Here {port} is the port of the ganache which is already running locally.
